### PR TITLE
Symmetric percentiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
 'use strict'
 
 const percentiles = module.exports.percentiles = [
+  0.001,
+  0.01,
+  0.1,
+  1,
   2.5,
+  10,
+  25,
   50,
   75,
   90,

--- a/test/hdr-js.js
+++ b/test/hdr-js.js
@@ -5,7 +5,7 @@ const hdr = require('hdr-histogram-js')
 const histPercentileObj = require('../')
 
 test('should return a valid hist as object', (t) => {
-  t.plan(18)
+  t.plan(24)
   const histogram = hdr.build({
     lowestDiscernibleValue: 1,
     highestTrackableValue: 100
@@ -30,7 +30,13 @@ test('should return a valid hist as object', (t) => {
   const withPercentiles = histPercentileObj.addPercentiles(histogram, result)
   t.ok(withPercentiles)
   t.type(withPercentiles.average, 'number')
+  t.type(withPercentiles.p0_001, 'number')
+  t.type(withPercentiles.p0_01, 'number')
+  t.type(withPercentiles.p0_1, 'number')
+  t.type(withPercentiles.p1, 'number')
   t.type(withPercentiles.p2_5, 'number')
+  t.type(withPercentiles.p10, 'number')
+  t.type(withPercentiles.p25, 'number')
   t.type(withPercentiles.p50, 'number')
   t.type(withPercentiles.p75, 'number')
   t.type(withPercentiles.p90, 'number')


### PR DESCRIPTION
As mentioned in https://github.com/mcollina/autocannon/pull/144#issuecomment-406579868,
for some stats having the lowest percentiles is more useful than having
the highest percentiles.

This adds percentiles so that the same relevant values are available for
stats where the highest values are most interesting, as for stats where
the lowest values are most interesting.