### PR TITLE
Upgrade HdrHistogramJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,5 +76,8 @@ function getStdDeviation (hist) {
   if (typeof hist.stddev === 'function') {
     return hist.stddev()
   }
-  return hist.getStdDeviation()
+  if (typeof hist.getStdDeviation === 'function') {
+    return hist.getStdDeviation()
+  }
+  return hist.stdDeviation
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "tap": "^12.0.1"
   },
   "dependencies": {
-    "hdr-histogram-js": "^1.0.0"
+    "hdr-histogram-js": "^2.0.1"
   }
 }

--- a/test/hdr-js.js
+++ b/test/hdr-js.js
@@ -81,3 +81,12 @@ test('should return expected numbers', (t) => {
   t.equal(withPercentiles.p99_99, 6)
   t.equal(withPercentiles.p99_999, 6)
 })
+
+test('should return a valid hist as object from a WASM histogram', (t) => {
+  t.plan(1)
+  hdr.initWebAssemblySync()
+  const histogram = hdr.build({
+    useWebAssembly: true
+  })
+  t.ok(histPercentileObj.histAsObj(histogram))
+})


### PR DESCRIPTION
This PR upgrades HdrHIstogramJS and fixes a compatibility issue with WASM histograms